### PR TITLE
Convert player state to jotai atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Gremlin Nob (Elite):
 Healing/Upgrading a card at rest site:
 ![sts-4](https://github.com/toddkao/slay-the-dungeon/assets/10605836/d977f0a6-7a11-4180-87fd-1944c4b9ee5c)
 
+
+## Jotai Migration
+
+This project previously used MobX with classes. The `playerAtom` in `src/jotaiPlayerState.ts` now replaces the old `PlayerState` class and the player rendering component reads from this atom using Jotai hooks. This marks the start of a wider migration away from MobX.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mobx": "^6.0.4",
     "mobx-react": "^7.0.5",
     "mobx-utils": "^6.0.3",
+    "jotai": "^2.0.3",
     "react": "^17.0.1",
     "react-arrow-master": "^0.3.2",
     "react-dom": "^17.0.1",

--- a/src/Game/Entities/Player/RenderPlayer.tsx
+++ b/src/Game/Entities/Player/RenderPlayer.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import styled from "styled-components";
 import { Column, Spacer } from "../../../Layout";
-import { PlayerState } from "./PlayerState";
+import { useAtomValue } from "jotai";
+import { playerAtom } from "../../../jotaiPlayerState";
 import ironclad from "../../../Images/ironclad.png";
 import { StatusBar } from "../../Common/StatusBar";
-import { observer } from "mobx-react";
 import { BattleState } from "../../Battle/BattleState";
 import { HealthBar } from "../../Common/HealthBar";
 import { ReticleWrapper } from "../../Common/ReticleWrapper";
 
-export const RenderPlayer = observer(() => {
-  const playerState = PlayerState.get();
+export const RenderPlayer = () => {
+  const playerState = useAtomValue(playerAtom);
   const battleState = BattleState.get();
   const { health, block, maxHealth, statuses } = playerState;
   if (health === 0) {
@@ -32,7 +32,7 @@ export const RenderPlayer = observer(() => {
       </ReticleWrapper>
     </PlayerWrapper>
   );
-});
+};
 
 const PlayerWrapper = styled(Column)`
   position: relative;

--- a/src/jotaiPlayerState.ts
+++ b/src/jotaiPlayerState.ts
@@ -1,0 +1,130 @@
+import { atom } from 'jotai';
+import { uniqueId, range } from 'lodash';
+import { IStatus, StatusType, StatusTypeToIStatus } from './Game/Common/StatusBar';
+import { cardMap } from './Game/Cards/CardDefinitions';
+import { ICardWithId } from './Game/Cards/CardState';
+import { playAudioClip } from './Game/Common/utility';
+
+export enum PlayerClass {
+  IRONCLAD,
+  SILENT,
+}
+
+export interface PlayerState {
+  id: string;
+  health: number;
+  maxHealth: number;
+  block: number;
+  maxMana: number;
+  class: PlayerClass;
+  deck: ICardWithId[];
+  statuses: IStatus[];
+}
+
+const initialPlayerState: PlayerState = {
+  id: uniqueId(),
+  health: 80,
+  maxHealth: 80,
+  block: 0,
+  maxMana: 3,
+  class: PlayerClass.IRONCLAD,
+  deck: [
+    ...range(0, 5).map(() => ({ ...cardMap['Strike'], id: uniqueId() })),
+    ...range(0, 4).map(() => ({ ...cardMap['Defend'], id: uniqueId() })),
+    { ...cardMap['Bash'], id: uniqueId() },
+  ],
+  statuses: [],
+};
+
+export const playerAtom = atom<PlayerState>(initialPlayerState);
+
+export const playerStrengthAtom = atom((get) =>
+  get(playerAtom).statuses.find((s) => s.type === StatusType.STRENGTH)?.amount || 0
+);
+
+export const playerDexterityAtom = atom((get) =>
+  get(playerAtom).statuses.find((s) => s.type === StatusType.DEXTERITY)?.amount || 0
+);
+
+export const playerDamageMultiplierAtom = atom((get) =>
+  get(playerAtom).statuses.find((s) => s.type === StatusType.WEAK) ? 0.75 : 1
+);
+
+export const playerBlockMultiplierAtom = atom(() => 1);
+
+export const addStatusAtom = atom(null, (get, set, { type, amount = 1 }: { type: StatusType; amount?: number }) => {
+  const player = get(playerAtom);
+  const existing = player.statuses.find((s) => s.type === type);
+  if (existing) {
+    set(playerAtom, {
+      ...player,
+      statuses: player.statuses.map((s) =>
+        s.type === type ? { ...s, amount: s.amount + amount } : s
+      ),
+    });
+  } else {
+    set(playerAtom, {
+      ...player,
+      statuses: [
+        ...player.statuses,
+        {
+          type,
+          amount,
+          degrades: StatusTypeToIStatus[type]?.degrades,
+          fleeting: StatusTypeToIStatus[type]?.fleeting,
+        },
+      ],
+    });
+  }
+  playAudioClip(StatusTypeToIStatus[type]?.audio);
+});
+
+export const removeStatusAtom = atom(null, (get, set, args: { type: StatusType; amount?: number }) => {
+  const { type, amount = -1 } = args;
+  set(addStatusAtom, { type, amount: amount * -1 });
+});
+
+export const clearBlockAtom = atom(null, (get, set) => {
+  const player = get(playerAtom);
+  set(playerAtom, { ...player, block: 0 });
+});
+
+export const addBlockAtom = atom(null, (get, set, amount: number) => {
+  const player = get(playerAtom);
+  const dexBonus = get(playerDexterityAtom);
+  set(playerAtom, { ...player, block: player.block + amount + dexBonus });
+});
+
+export const takeDamageAtom = atom(null, (get, set, amount: number) => {
+  const player = get(playerAtom);
+  let { block, health } = player;
+  if (block > amount) {
+    block -= amount;
+  } else if (block + health > amount) {
+    health -= amount - block;
+    block = 0;
+  } else {
+    health = 0;
+    block = 0;
+  }
+  set(playerAtom, { ...player, block, health });
+});
+
+export const resetPlayerAtom = atom(null, (get, set) => {
+  const player = get(playerAtom);
+  set(playerAtom, { ...player, health: player.maxHealth, block: 0, statuses: [] });
+});
+
+export const initializeBattleAtom = atom(null, (get, set) => {
+  const player = get(playerAtom);
+  set(playerAtom, { ...player, block: 0, statuses: [] });
+});
+
+export const addCardToDeckAtom = atom(null, (get, set, cardName: string) => {
+  const player = get(playerAtom);
+  const card = {
+    ...cardMap[cardName],
+    id: uniqueId(),
+  };
+  set(playerAtom, { ...player, deck: [...player.deck, card] });
+});


### PR DESCRIPTION
## Summary
- expand `playerAtom` with full player state and helper atoms
- switch `RenderPlayer` component to read from jotai state
- document start of MobX replacement

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*