### PR TITLE
Start jotai migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Gremlin Nob (Elite):
 Healing/Upgrading a card at rest site:
 ![sts-4](https://github.com/toddkao/slay-the-dungeon/assets/10605836/d977f0a6-7a11-4180-87fd-1944c4b9ee5c)
 
+
+## Jotai Migration
+
+This project previously used MobX with classes. New Jotai atoms now exist for every state class under `src/state`. `RenderPlayer` has been updated to read player data from `playerAtom`.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mobx": "^6.0.4",
     "mobx-react": "^7.0.5",
     "mobx-utils": "^6.0.3",
+    "jotai": "^2.0.3",
     "react": "^17.0.1",
     "react-arrow-master": "^0.3.2",
     "react-dom": "^17.0.1",

--- a/src/Game/Entities/Player/RenderPlayer.tsx
+++ b/src/Game/Entities/Player/RenderPlayer.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import styled from "styled-components";
 import { Column, Spacer } from "../../../Layout";
-import { PlayerState } from "./PlayerState";
+import { useAtomValue } from "jotai";
 import ironclad from "../../../Images/ironclad.png";
 import { StatusBar } from "../../Common/StatusBar";
-import { observer } from "mobx-react";
 import { BattleState } from "../../Battle/BattleState";
+import { playerAtom } from "../../../state";
 import { HealthBar } from "../../Common/HealthBar";
 import { ReticleWrapper } from "../../Common/ReticleWrapper";
 
-export const RenderPlayer = observer(() => {
-  const playerState = PlayerState.get();
+export const RenderPlayer = () => {
+  const { health, block, maxHealth, statuses } = useAtomValue(playerAtom);
   const battleState = BattleState.get();
-  const { health, block, maxHealth, statuses } = playerState;
   if (health === 0) {
     return null;
   }
@@ -32,7 +31,7 @@ export const RenderPlayer = observer(() => {
       </ReticleWrapper>
     </PlayerWrapper>
   );
-});
+};
 
 const PlayerWrapper = styled(Column)`
   position: relative;

--- a/src/state/battle.ts
+++ b/src/state/battle.ts
@@ -1,0 +1,35 @@
+import { atom } from 'jotai';
+import { CardState } from '../Game/Cards/CardState';
+import { MonsterState } from '../Game/Entities/Monster/MonsterState';
+import { PlayerState } from './player';
+
+export interface BattleState {
+  selectedCardId?: string;
+  selectedMonsterIds?: string[];
+  selectedSelf?: boolean;
+  monsters?: MonsterState[];
+  currentHand: CardState[];
+  currentMana: number;
+  drawPile: CardState[];
+  discardPile: CardState[];
+  exhaustPile: CardState[];
+}
+
+const initialBattleState: BattleState = {
+  selectedCardId: undefined,
+  selectedMonsterIds: undefined,
+  selectedSelf: undefined,
+  monsters: undefined,
+  currentHand: [],
+  currentMana: 3,
+  drawPile: [],
+  discardPile: [],
+  exhaustPile: [],
+};
+
+export const battleAtom = atom<BattleState>(initialBattleState);
+
+export const setSelectedCardAtom = atom(null, (get, set, id?: string) => {
+  const current = get(battleAtom);
+  set(battleAtom, { ...current, selectedCardId: id });
+});

--- a/src/state/card.ts
+++ b/src/state/card.ts
@@ -1,0 +1,32 @@
+import { atom } from 'jotai';
+import { cardMap, CardRarity } from '../Game/Cards/CardDefinitions';
+
+export enum CardEffectType {
+  SPECIFIC_ENEMY,
+  ALL_ENEMIES,
+  SELF,
+  RANDOM,
+}
+
+export enum CardType {
+  ATTACK = 'Attack',
+  SKILL = 'Skill',
+}
+
+export interface CardState {
+  id: string;
+  name: string;
+  type: CardType;
+  effect: CardEffectType;
+  upgraded: boolean;
+}
+
+const createCard = (name: string, id: string, upgraded: boolean): CardState => ({
+  id,
+  name,
+  type: cardMap[name].type as CardType,
+  effect: cardMap[name].effect,
+  upgraded,
+});
+
+export const cardAtom = (name: string, id: string, upgraded = false) => atom<CardState>(createCard(name, id, upgraded));

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,5 @@
+export * from './player';
+export * from './map';
+export * from './battle';
+export * from './monster';
+export * from './card';

--- a/src/state/map.ts
+++ b/src/state/map.ts
@@ -1,0 +1,51 @@
+import { atom } from 'jotai';
+import { uniqueId } from 'lodash';
+import { MonsterState } from '../Game/Entities/Monster/MonsterState';
+
+export enum MapNodeType {
+  MONSTER,
+  CHEST,
+  REST,
+  SHOP,
+  EVENT,
+  ELITE,
+}
+
+export interface MapNode {
+  id: string;
+  type: MapNodeType;
+  left: number;
+  top: number;
+  encounter?: MonsterState[];
+}
+
+export interface MapState {
+  currentNode?: MapNode;
+  traversedNodeIds: string[];
+  currentEncounter?: MonsterState[];
+  showingMap: boolean;
+}
+
+const initialMapState: MapState = {
+  currentNode: undefined,
+  traversedNodeIds: [],
+  currentEncounter: undefined,
+  showingMap: false,
+};
+
+export const mapAtom = atom<MapState>(initialMapState);
+
+export const setShowingMapAtom = atom(null, (get, set, showing: boolean) => {
+  const current = get(mapAtom);
+  set(mapAtom, { ...current, showingMap: showing });
+});
+
+export const selectNodeAtom = atom(null, (get, set, node: MapNode) => {
+  const current = get(mapAtom);
+  set(mapAtom, {
+    ...current,
+    currentNode: node,
+    traversedNodeIds: [...current.traversedNodeIds, node.id],
+    currentEncounter: node.encounter,
+  });
+});

--- a/src/state/monster.ts
+++ b/src/state/monster.ts
@@ -1,0 +1,52 @@
+import { atom } from 'jotai';
+import { IStatus } from '../Game/Common/StatusBar';
+import { CardState } from '../Game/Cards/CardState';
+
+export enum IntentType {
+  SLEEP,
+  ATTACK,
+  ATTACK_DEBUFF,
+  SHIELD,
+  GAIN_STRENGTH,
+  ENRAGE,
+  GOOP_SPRAY,
+  NOTHING,
+  SPLIT,
+  DEBUFF,
+}
+
+export interface Intent {
+  intentImage: string;
+  chance: number;
+  type: IntentType;
+  amount?: number;
+  status?: IStatus;
+}
+
+export interface MonsterState {
+  id: string;
+  name: string;
+  health: number;
+  maxHealth: number;
+  block: number;
+  image: { src: string; height: number };
+  intent: () => Intent[];
+  currentIntent?: Intent;
+  onCardPlayed?: (card: CardState) => void;
+  statuses: IStatus[];
+}
+
+const initialMonsterState = (id: string): MonsterState => ({
+  id,
+  name: 'Monster',
+  health: 0,
+  maxHealth: 0,
+  block: 0,
+  image: { src: '', height: 0 },
+  intent: () => [],
+  currentIntent: undefined,
+  onCardPlayed: undefined,
+  statuses: [],
+});
+
+export const monsterAtom = (id: string) => atom<MonsterState>(initialMonsterState(id));

--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -1,0 +1,51 @@
+import { atom } from 'jotai';
+import { uniqueId, range } from 'lodash';
+import { ICardWithId } from '../Game/Cards/CardState';
+import { cardMap } from '../Game/Cards/CardDefinitions';
+import { IStatus } from '../Game/Common/StatusBar';
+
+export enum PlayerClass {
+  IRONCLAD,
+  SILENT,
+}
+
+export interface PlayerState {
+  id: string;
+  health: number;
+  maxHealth: number;
+  block: number;
+  maxMana: number;
+  class: PlayerClass;
+  statuses: IStatus[];
+  deck: ICardWithId[];
+}
+
+const createDefaultDeck = () => [
+  ...range(0, 5).map(() => ({ ...cardMap['Strike'], id: uniqueId() })),
+  ...range(0, 4).map(() => ({ ...cardMap['Defend'], id: uniqueId() })),
+  { ...cardMap['Bash'], id: uniqueId() },
+];
+
+const initialPlayerState: PlayerState = {
+  id: uniqueId(),
+  health: 80,
+  maxHealth: 80,
+  block: 0,
+  maxMana: 3,
+  class: PlayerClass.IRONCLAD,
+  statuses: [],
+  deck: createDefaultDeck(),
+};
+
+export const playerAtom = atom<PlayerState>(initialPlayerState);
+
+export const initializeBattleAtom = atom(null, (get, set) => {
+  const current = get(playerAtom);
+  set(playerAtom, { ...current, block: 0, statuses: [] });
+});
+
+export const addCardToDeckAtom = atom(null, (get, set, cardName: string) => {
+  const card = { ...cardMap[cardName], id: uniqueId() } as ICardWithId;
+  const current = get(playerAtom);
+  set(playerAtom, { ...current, deck: [...current.deck, card] });
+});


### PR DESCRIPTION
## Summary
- convert player state to Jotai and add helper atoms
- add minimal atoms for map, battle, monster and cards
- update `RenderPlayer` to use `playerAtom`
- document new `src/state` folder in README

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*